### PR TITLE
feat(android): update library

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,4 @@
 
 dependencies {
-	implementation 'androidx.biometric:biometric:1.0.1'
+	implementation 'androidx.biometric:biometric:1.1.0'
 }

--- a/android/manifest
+++ b/android/manifest
@@ -2,7 +2,7 @@
 # this is your module manifest and used by Titanium
 # during compilation, packaging, distribution, etc.
 #
-version: 3.0.3
+version: 3.1.0
 apiversion: 4
 architectures: arm64-v8a armeabi-v7a x86 x86_64
 description: titanium-identity

--- a/android/src/ti/identity/FingerPrintHelper.java
+++ b/android/src/ti/identity/FingerPrintHelper.java
@@ -15,17 +15,9 @@ import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyPermanentlyInvalidatedException;
 import android.security.keystore.KeyProperties;
 import android.util.Base64;
-
 import androidx.biometric.BiometricManager;
 import androidx.biometric.BiometricPrompt;
 import androidx.fragment.app.FragmentActivity;
-
-import org.appcelerator.kroll.KrollDict;
-import org.appcelerator.kroll.KrollFunction;
-import org.appcelerator.kroll.KrollObject;
-import org.appcelerator.kroll.common.Log;
-import org.appcelerator.titanium.TiApplication;
-
 import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.util.HashMap;
@@ -33,10 +25,14 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
-
 import javax.crypto.Cipher;
 import javax.crypto.KeyGenerator;
 import javax.crypto.SecretKey;
+import org.appcelerator.kroll.KrollDict;
+import org.appcelerator.kroll.KrollFunction;
+import org.appcelerator.kroll.KrollObject;
+import org.appcelerator.kroll.common.Log;
+import org.appcelerator.titanium.TiApplication;
 
 public class FingerPrintHelper extends BiometricPrompt.AuthenticationCallback
 {
@@ -91,7 +87,10 @@ public class FingerPrintHelper extends BiometricPrompt.AuthenticationCallback
 	private boolean canUseDeviceBiometrics()
 	{
 		if ((Build.VERSION.SDK_INT >= 23) && (mBiometricManager != null)) {
-			return mBiometricManager.canAuthenticate(BiometricManager.Authenticators.DEVICE_CREDENTIAL | BiometricManager.Authenticators.BIOMETRIC_STRONG | BiometricManager.Authenticators.BIOMETRIC_WEAK) == BiometricManager.BIOMETRIC_SUCCESS;
+			return mBiometricManager.canAuthenticate(BiometricManager.Authenticators.DEVICE_CREDENTIAL
+													 | BiometricManager.Authenticators.BIOMETRIC_STRONG
+													 | BiometricManager.Authenticators.BIOMETRIC_WEAK)
+				== BiometricManager.BIOMETRIC_SUCCESS;
 		}
 		return false;
 	}
@@ -275,7 +274,9 @@ public class FingerPrintHelper extends BiometricPrompt.AuthenticationCallback
 		String error = "";
 		KrollDict response = new KrollDict();
 
-		int canAuthenticate = mBiometricManager.canAuthenticate(BiometricManager.Authenticators.DEVICE_CREDENTIAL |BiometricManager.Authenticators.BIOMETRIC_STRONG | BiometricManager.Authenticators.BIOMETRIC_WEAK);
+		int canAuthenticate = mBiometricManager.canAuthenticate(BiometricManager.Authenticators.DEVICE_CREDENTIAL
+																| BiometricManager.Authenticators.BIOMETRIC_STRONG
+																| BiometricManager.Authenticators.BIOMETRIC_WEAK);
 		boolean hardwareDetected = canAuthenticate != BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE
 								   && canAuthenticate != BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE;
 		boolean hasFingerprints = canAuthenticate != BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED;
@@ -327,10 +328,13 @@ public class FingerPrintHelper extends BiometricPrompt.AuthenticationCallback
 			Executor executor = Executors.newSingleThreadExecutor();
 			BiometricPrompt biometricPrompt =
 				new BiometricPrompt((FragmentActivity) TiApplication.getAppCurrentActivity(), executor, this);
-			BiometricPrompt.PromptInfo promptInfo = new BiometricPrompt.PromptInfo.Builder()
-														.setTitle("Enter your device credentials")
-														.setAllowedAuthenticators(BiometricManager.Authenticators.DEVICE_CREDENTIAL |BiometricManager.Authenticators.BIOMETRIC_STRONG | BiometricManager.Authenticators.BIOMETRIC_WEAK)
-														.build();
+			BiometricPrompt.PromptInfo promptInfo =
+				new BiometricPrompt.PromptInfo.Builder()
+					.setTitle("Enter your device credentials")
+					.setAllowedAuthenticators(BiometricManager.Authenticators.DEVICE_CREDENTIAL
+											  | BiometricManager.Authenticators.BIOMETRIC_STRONG
+											  | BiometricManager.Authenticators.BIOMETRIC_WEAK)
+					.build();
 			biometricPrompt.authenticate(promptInfo);
 		} else if (response.containsKey("error")) {
 			onError(response.getString("error"));

--- a/android/src/ti/identity/FingerPrintHelper.java
+++ b/android/src/ti/identity/FingerPrintHelper.java
@@ -15,25 +15,28 @@ import android.security.keystore.KeyGenParameterSpec;
 import android.security.keystore.KeyPermanentlyInvalidatedException;
 import android.security.keystore.KeyProperties;
 import android.util.Base64;
+
 import androidx.biometric.BiometricManager;
 import androidx.biometric.BiometricPrompt;
 import androidx.fragment.app.FragmentActivity;
-import java.security.KeyStore;
-import java.security.KeyStoreException;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-import java.util.Optional;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
-import javax.crypto.Cipher;
-import javax.crypto.KeyGenerator;
-import javax.crypto.SecretKey;
+
 import org.appcelerator.kroll.KrollDict;
 import org.appcelerator.kroll.KrollFunction;
 import org.appcelerator.kroll.KrollObject;
 import org.appcelerator.kroll.common.Log;
 import org.appcelerator.titanium.TiApplication;
+
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+import javax.crypto.Cipher;
+import javax.crypto.KeyGenerator;
+import javax.crypto.SecretKey;
 
 public class FingerPrintHelper extends BiometricPrompt.AuthenticationCallback
 {
@@ -88,9 +91,7 @@ public class FingerPrintHelper extends BiometricPrompt.AuthenticationCallback
 	private boolean canUseDeviceBiometrics()
 	{
 		if ((Build.VERSION.SDK_INT >= 23) && (mBiometricManager != null)) {
-			if (mBiometricManager.canAuthenticate() == BiometricManager.BIOMETRIC_SUCCESS) {
-				return true;
-			}
+			return mBiometricManager.canAuthenticate(BiometricManager.Authenticators.DEVICE_CREDENTIAL | BiometricManager.Authenticators.BIOMETRIC_STRONG | BiometricManager.Authenticators.BIOMETRIC_WEAK) == BiometricManager.BIOMETRIC_SUCCESS;
 		}
 		return false;
 	}
@@ -274,7 +275,7 @@ public class FingerPrintHelper extends BiometricPrompt.AuthenticationCallback
 		String error = "";
 		KrollDict response = new KrollDict();
 
-		int canAuthenticate = mBiometricManager.canAuthenticate();
+		int canAuthenticate = mBiometricManager.canAuthenticate(BiometricManager.Authenticators.DEVICE_CREDENTIAL |BiometricManager.Authenticators.BIOMETRIC_STRONG | BiometricManager.Authenticators.BIOMETRIC_WEAK);
 		boolean hardwareDetected = canAuthenticate != BiometricManager.BIOMETRIC_ERROR_HW_UNAVAILABLE
 								   && canAuthenticate != BiometricManager.BIOMETRIC_ERROR_NO_HARDWARE;
 		boolean hasFingerprints = canAuthenticate != BiometricManager.BIOMETRIC_ERROR_NONE_ENROLLED;
@@ -328,7 +329,7 @@ public class FingerPrintHelper extends BiometricPrompt.AuthenticationCallback
 				new BiometricPrompt((FragmentActivity) TiApplication.getAppCurrentActivity(), executor, this);
 			BiometricPrompt.PromptInfo promptInfo = new BiometricPrompt.PromptInfo.Builder()
 														.setTitle("Enter your device credentials")
-														.setDeviceCredentialAllowed(true)
+														.setAllowedAuthenticators(BiometricManager.Authenticators.DEVICE_CREDENTIAL |BiometricManager.Authenticators.BIOMETRIC_STRONG | BiometricManager.Authenticators.BIOMETRIC_WEAK)
 														.build();
 			biometricPrompt.authenticate(promptInfo);
 		} else if (response.containsKey("error")) {


### PR DESCRIPTION
* update biometric library. Changelog:
```
* Added backwards-compatible support for new biometric authentication features and API updates introduced in Android 11.
* Significantly reduced the app size footprint of the library (by >100 KB, in some cases).
* Removed various sources of memory leaks that were previously caused by the library.
* Fixed class verification failures that could affect performance on older Android versions.
* Made various additional improvements to the stability and behavior of the library.
```
https://developer.android.com/jetpack/androidx/releases/biometric#version_110_3

* changed `canAuthenticate` to remove deprecation warnings (allowing all, could be a parameter for stronger security later)
* same for `setDeviceCredentialAllowed`


[ti.identity-android-3.1.0.zip](https://github.com/appcelerator-modules/titanium-identity/files/7467328/ti.identity-android-3.1.0.zip)

**Also**
And still would love to see https://github.com/appcelerator-modules/titanium-identity/pull/48 merged so more texts can be set